### PR TITLE
Replace path by path2 module

### DIFF
--- a/tasks/shared/link.js
+++ b/tasks/shared/link.js
@@ -1,7 +1,7 @@
 var registerTask = require('../../lib/register-task');
 var getShipit = require('../../lib/get-shipit');
 var sprintf = require('sprintf-js').sprintf;
-var path = require('path');
+var path = require('path2/posix');
 var chalk = require('chalk');
 var Bluebird = require('bluebird');
 


### PR DESCRIPTION
Hi,

Replacing _path_ module by _path2_ permits to use this package with non-posix deployment machines (for example Windows).

Thanks.
