### PR TITLE
Fixed undefined run method and event name

### DIFF
--- a/tasks/shared/index.js
+++ b/tasks/shared/index.js
@@ -15,7 +15,7 @@ module.exports = function (gruntOrShipit) {
     'shared:link',
   ]);
 
-  gruntOrShipit.on('deploy:published', function () {
-    gruntOrShipit.run('shared');
+  gruntOrShipit.on('published', function () {
+    gruntOrShipit.start('shared');
   });
 };


### PR DESCRIPTION
Hello,

I was trying to use this module with last version of shipit, but I found some issues:
- Method .run doesn't exist: **use _.start_ method instead of .run**
- Event deploy:published doesn't exists: **use _published_ event instead of deploy:published**

I hope that it helps
