### PR TITLE
Add tests (fix #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.log
+TEMPFILE.*
+node_modules

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The default setting of `false` is a safety precaution to prevent unintentionally
 Type: `String`
 Default: `shared.basePath`
 
-The path that will serve as the source for your symlink. This is usually the same as `shared.basePath`, however it can [necessary to set this in a `chroot` environment](https://github.com/timkelty/shipit-shared/issues/7).
+The path that will serve as the source for your symlink. This is usually the same as `shared.basePath`, however it can be [necessary to set this in a `chroot` environment](https://github.com/timkelty/shipit-shared/issues/7).
 
 ### `shared.triggerEvent`
 Type: `String`, `Boolean`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on the concept of `linked_files`/`linked_dirs` from [Capistrano](http://ca
 **Features:**
 
 - By default, the `shared` task is triggered on the `updated` event from [shipit-deploy](https://github.com/shipitjs/shipit-deploy)
-- All neccesary directories are always created for you, whether you are linking a file or a directory.
+- All necessary directories are always created for you, whether you are linking a file or a directory.
 - Optionally set permissions on files.
 - Works via [shipit-cli](https://github.com/shipitjs/shipit) and [grunt-shipit](https://github.com/shipitjs/grunt-shipit)
 
@@ -62,7 +62,7 @@ To trigger on the deploy `published` event, you can simply deploy:
 shipit staging deploy
 ```
 
-Or you can run the tasks separatly :
+Or you can run the tasks separately :
 
 ```
 shipit staging shared
@@ -138,18 +138,22 @@ Default: `updated`
 
 Trigger `shared` task on given event name.
 Set to `false` to prevent task from listening to any events.
+(note: Some part of shipit-shared *besides initConfig* needs to be run before it can listen for events)
 
 ## Events
 - `shared`
   + `shared:prepare`
     + `shared:create-dirs`
       * Emit event `sharedDirsCreated`
-    + `shared:link`
-      * `shared:link-dirs`
-      - Emit event `sharedFilesDirs`
-    * `shared:link-files`
-      - Emit event `sharedFilesLinked`
+    + `shared:set-permissions`
+      * Emit event `sharedPermissionsSet`
+  + `shared:link`
+    + `shared:link-dirs`
+      * Emit event `sharedFilesDirs`
+    + `shared:link-files`
+      * Emit event `sharedFilesLinked`
   + `shared:end`
+    * Emit event `sharedEnd`
 
 ## License
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,4 +1,4 @@
-var path = require('path');
+var path = require('path2/posix');
 var Promise = require('bluebird');
 var _ = require('lodash');
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha --recursive"
+    "test": "mocha --reporter spec"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/timkelty/shipit-shared",
   "devDependencies": {
+    "chai": "^3.0.0",
     "mocha": "^2.1.0",
     "shipit-cli": "^1.1.0",
     "sinon": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
   },
   "homepage": "https://github.com/timkelty/shipit-shared",
   "devDependencies": {
-    "chai": "^1.10.0",
     "mocha": "^2.1.0",
-    "rewire": "^2.1.4",
     "shipit-cli": "^1.1.0",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",

--- a/tasks/shared/create-dirs.js
+++ b/tasks/shared/create-dirs.js
@@ -4,7 +4,7 @@ var util = require('util');
 var init = require('../../lib/init');
 var mapPromise = require('../../lib/map-promise');
 var Promise = require('bluebird');
-var path = require('path');
+var path = require('path2/posix');
 
 /**
  * Create required directories for linked files and dirs.

--- a/tasks/shared/set-permissions.js
+++ b/tasks/shared/set-permissions.js
@@ -4,7 +4,7 @@ var util = require('util');
 var init = require('../../lib/init');
 var mapPromise = require('../../lib/map-promise');
 var Promise = require('bluebird');
-var path = require('path');
+var path = require('path2/posix');
 var _ = require('lodash');
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,300 @@
+// object variables
+var fs = require('fs');
+var mocha = require('mocha');
+var sinon = require('sinon');
+require('sinon-as-promised');
+var sinonchai = require('sinon-chai');
+var expect = require('chai').use(require('sinon-chai')).expect;
+var Shipit = require('shipit-cli');
+
+var remoteStub;
+
+describe('Shipit-Shared', function () {
+  describe('Worker functions', function () {
+    //Create new shipit instance per-test, 
+    //these bits can and will be modified if needed to suit test
+    beforeEach(function () {
+      shipit = new Shipit({
+        environment: 'test',
+        log: sinon.stub()
+      });
+      shipit.stage = 'test';
+
+      require('../')(shipit);
+
+      shipit.initConfig({
+        test: {
+          deployTo: '/tmplocal/deploy',
+          shared: {
+            overwrite: true,
+            dirs: [
+              'storage',
+              {
+                path: 'db',
+                overwrite: false,
+                chmod: '-R 777',
+              }
+            ],
+            files: [
+              'environment.yml',
+              {
+                path: 'config/database.yml',
+                overwrite: false,
+                chmod: '755',
+              }
+            ],
+          }
+        }
+      });
+      shipit.releaseDirname = '7357';
+
+      remoteStub = sinon.stub(shipit, 'remote').resolves([]);
+    });
+
+    it('shared:create-dirs', function(done) {
+      shipit.start('shared:create-dirs', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('mkdir -p /tmplocal/deploy/shared/storage');
+        expect(shipit.remote).calledWith('mkdir -p /tmplocal/deploy/shared/db');
+        expect(shipit.remote).calledWith('mkdir -p $(dirname /tmplocal/deploy/shared/environment.yml)');
+        expect(shipit.remote).calledWith('mkdir -p $(dirname /tmplocal/deploy/shared/config/database.yml)');
+        expect(remoteStub.callCount).to.equal(4);
+        done();
+      });
+    });
+
+    it('shared:set-permissions', function(done) {
+      shipit.start('shared:set-permissions', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('chmod -R 777 /tmplocal/deploy/shared/db');
+        expect(shipit.remote).calledWith('chmod 755 /tmplocal/deploy/shared/config/database.yml');
+        expect(remoteStub.callCount).to.equal(2);
+        done();
+      });
+    });
+
+    it('shared:link:dirs', function(done) {
+      shipit.start('shared:link:dirs', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('if ( [ -e "/tmplocal/deploy/releases/7357/db" ] && ! [ -h "/tmplocal/deploy/releases/7357/db" ] ); then echo false; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/storage" ] ); then rm -rf "/tmplocal/deploy/releases/7357/storage" 2> /dev/null; ln -s "/tmplocal/deploy/shared/storage" "/tmplocal/deploy/releases/7357/storage"; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/db" ] ); then rm -rf "/tmplocal/deploy/releases/7357/db" 2> /dev/null; ln -s "/tmplocal/deploy/shared/db" "/tmplocal/deploy/releases/7357/db"; fi');
+        expect(remoteStub.callCount).to.equal(3);
+        done();
+      });
+    });
+
+    it('shared:link:files', function(done) {
+      shipit.start('shared:link:files', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('if ( [ -e "/tmplocal/deploy/releases/7357/config/database.yml" ] && ! [ -h "/tmplocal/deploy/releases/7357/config/database.yml" ] ); then echo false; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/config/database.yml" ] ); then rm -rf "/tmplocal/deploy/releases/7357/config/database.yml" 2> /dev/null; ln -s "/tmplocal/deploy/shared/config/database.yml" "/tmplocal/deploy/releases/7357/config/database.yml"; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/environment.yml" ] ); then rm -rf "/tmplocal/deploy/releases/7357/environment.yml" 2> /dev/null; ln -s "/tmplocal/deploy/shared/environment.yml" "/tmplocal/deploy/releases/7357/environment.yml"; fi');
+        expect(remoteStub.callCount).to.equal(3);
+        done();
+      });
+    });
+
+    it('alternative overwrite flags for shared:link:dirs', function(done) {
+      //quickly flip-flop overwrite flags in config
+      shipit.initConfig({
+        test: {
+          deployTo: '/tmplocal/deploy',
+          shared: {
+            overwrite: false,
+            dirs: [
+              'storage',
+              {
+                path: 'db',
+                overwrite: true,
+              }
+            ],
+            files: [],
+          }
+        }
+      });
+      shipit.start('shared:link:dirs', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('if ( [ -e "/tmplocal/deploy/releases/7357/storage" ] && ! [ -h "/tmplocal/deploy/releases/7357/storage" ] ); then echo false; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/storage" ] ); then rm -rf "/tmplocal/deploy/releases/7357/storage" 2> /dev/null; ln -s "/tmplocal/deploy/shared/storage" "/tmplocal/deploy/releases/7357/storage"; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/db" ] ); then rm -rf "/tmplocal/deploy/releases/7357/db" 2> /dev/null; ln -s "/tmplocal/deploy/shared/db" "/tmplocal/deploy/releases/7357/db"; fi');
+        expect(remoteStub.callCount).to.equal(3);
+        done();
+      });
+    });
+
+    it('alternative overwrite flags for shared:link:files', function(done) {
+      //quickly flip-flop overwrite flags in config
+      shipit.initConfig({
+        test: {
+          deployTo: '/tmplocal/deploy',
+          shared: {
+            overwrite: false,
+            dirs: [],
+            files: [
+              'environment.yml',
+              {
+                path: 'config/database.yml',
+                overwrite: true,
+              }
+            ],
+          }
+        }
+      });
+      shipit.start('shared:link:files', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('if ( [ -e "/tmplocal/deploy/releases/7357/environment.yml" ] && ! [ -h "/tmplocal/deploy/releases/7357/environment.yml" ] ); then echo false; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/config/database.yml" ] ); then rm -rf "/tmplocal/deploy/releases/7357/config/database.yml" 2> /dev/null; ln -s "/tmplocal/deploy/shared/config/database.yml" "/tmplocal/deploy/releases/7357/config/database.yml"; fi');
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/environment.yml" ] ); then rm -rf "/tmplocal/deploy/releases/7357/environment.yml" 2> /dev/null; ln -s "/tmplocal/deploy/shared/environment.yml" "/tmplocal/deploy/releases/7357/environment.yml"; fi');
+        expect(remoteStub.callCount).to.equal(3);
+        done();
+      });
+    });
+
+    afterEach(function () {
+      shipit.remote.restore();
+    });
+  });
+  describe('Overall functionality', function () {
+    //Create new shipit instance per-test, 
+    //these bits can and will be modified if needed to suit test
+    beforeEach(function () {
+      shipit = new Shipit({
+        environment: 'test',
+        log: sinon.stub()
+        // log: console.log()
+      });
+      shipit.stage = 'test';
+
+      require('../')(shipit);
+      shipit.releaseDirname = '7357';
+
+      remoteStub = sinon.stub(shipit, 'remote').resolves([]);
+    });
+
+    it('Overall Execution and basePath', function(done) {
+      shipit.initConfig({
+        test: {
+          deployTo: '/tmplocal/deploy',
+          shared: {
+            overwrite: true,
+            basePath: 'TRANS',
+            dirs: [
+              'storage',
+              {
+                path: 'db',
+                overwrite: false,
+                chmod: '-R 777',
+              }
+            ],
+            files: [
+              'environment.yml',
+              {
+                path: 'config/database.yml',
+                overwrite: false,
+                chmod: '755',
+              }
+            ],
+          }
+        }
+      });
+      shipit.start('shared', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('mkdir -p TRANS/storage');
+        expect(shipit.remote).calledWith('mkdir -p TRANS/db');
+        expect(shipit.remote).calledWith('mkdir -p $(dirname TRANS/environment.yml)');
+        expect(shipit.remote).calledWith('mkdir -p $(dirname TRANS/config/database.yml)');
+
+        expect(shipit.remote).calledWith('chmod -R 777 TRANS/db');
+        expect(shipit.remote).calledWith('chmod 755 TRANS/config/database.yml');
+
+        expect(shipit.remote).calledWith('if ( [ -e "/tmplocal/deploy/releases/7357/db" ] && ! [ -h "/tmplocal/deploy/releases/7357/db" ] ); then echo false; fi');
+
+        expect(shipit.remote).calledWith('if ( [ -e "/tmplocal/deploy/releases/7357/config/database.yml" ] && ! [ -h "/tmplocal/deploy/releases/7357/config/database.yml" ] ); then echo false; fi');
+        expect(remoteStub.callCount).to.equal(12);
+        done();
+      });
+    });
+
+  it('symlinkPath', function(done) {
+      shipit.initConfig({
+        test: {
+          deployTo: '/tmplocal/deploy',
+          shared: {
+            overwrite: true,
+            basePath: 'TRANS',
+            symlinkPath: 'SYMTRANS',
+            dirs: [
+              'storage',
+              {
+                path: 'db',
+                overwrite: false,
+                chmod: '-R 777',
+              }
+            ],
+            files: [
+              'environment.yml',
+              {
+                path: 'config/database.yml',
+                overwrite: false,
+                chmod: '755',
+              }
+            ],
+          }
+        }
+      });
+      shipit.start('shared:link', function (err) {
+        if (err) throw err;
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/environment.yml" ] ); then rm -rf "/tmplocal/deploy/releases/7357/environment.yml" 2> /dev/null; ln -s "SYMTRANS/environment.yml" "/tmplocal/deploy/releases/7357/environment.yml"; fi');
+
+        expect(shipit.remote).calledWith('if ( ! [ -h "/tmplocal/deploy/releases/7357/storage" ] ); then rm -rf "/tmplocal/deploy/releases/7357/storage" 2> /dev/null; ln -s "SYMTRANS/storage" "/tmplocal/deploy/releases/7357/storage"; fi');
+        
+        expect(remoteStub.callCount).to.equal(6);
+        done();
+      });
+    });
+
+    it('triggerEvent (minimum 2000ms)', function(done) {
+      this.timeout(5000);
+      shipit.initConfig({
+        test: {
+          deployTo: '/tmplocal/deploy',
+          shared: {
+            overwrite: true,
+            triggerEvent: 'testTrigger',
+            dirs: [
+              'storage',
+              {
+                path: 'db',
+                overwrite: false,
+                chmod: '-R 777',
+              }
+            ],
+            files: [
+              'environment.yml',
+              {
+                path: 'config/database.yml',
+                overwrite: false,
+                chmod: '755',
+              }
+            ],
+          }
+        }
+      });
+
+      shipit.start('shared:link', function (err) {
+        if (err) throw err;
+      });
+
+      shipit.emit('testTrigger');
+      setTimeout(function(){
+        expect(remoteStub.callCount).to.equal(12);
+        done();
+      }, 2000);
+    });
+
+    afterEach(function () {
+      shipit.remote.restore();
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ require('sinon-as-promised');
 var sinonchai = require('sinon-chai');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
-
+var shipit; //local-to-test temporary variable
 var remoteStub;
 
 describe('Shipit-Shared', function () {


### PR DESCRIPTION
Also includes some spellcheck and corrections to inconsistencies in the README, slight fixes to fix on-windows compatibility (not using path2/posix before now).

Unfortunately what the sinon.stubs are looking for aren't terribly human-readable or short, but there's not a particularly good way to fix that - as we need a complete and perfect match for the commands to work in unix as expected anyway.
