### PR TITLE
Update npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "bluebird": "^3.0.6",
     "chalk": "^1.1.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.12.0",
     "mkdirp": "^0.5.0",
     "path-is-absolute": "^1.0.0",
     "path2": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "chalk": "^1.1.1",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.0",
-    "moment": "^2.9.0",
     "path-is-absolute": "^1.0.0",
     "path2": "^0.1.0",
     "shipit-deploy": "^2.1.2",


### PR DESCRIPTION
There are two changes in package.json which updates/removes some package dependency.

First, Removal of moment package dependency.
[Due to nodesource's research](https://nodesecurity.io/advisories/moment_regular-expression-denial-of-service), Semver of moment (`^2.9.0`) is insecure. It should be updated.
Anyway, moment is not used from any sources in this package. So it should just be removed.

Second, lodash.
lodash v4 is released, but current semver of `lodash` installs lodash v3. which is outdated.
It should be updated.

Cheers 🍺 
